### PR TITLE
Add compatibility for Lumen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes History
 
+2.1.2
+-----
+Add compatibility with Lumen 8.0+
+
 2.1.1
 -----
 Declare compatibility with Laravel 11

--- a/README.md
+++ b/README.md
@@ -39,6 +39,40 @@ You can add more custom checks - just add a class implementing
 `\Saritasa\LaravelHealthCheck\Contracts\ServiceHealthChecker` interface with single method `check()` 
 that must return instance of `\Saritasa\LaravelHealthCheck\Contracts\CheckResult`.
 
+## Laravel Lumen 8.0+
+
+Install the ```saritasa/laravel-healthcheck``` package:  
+  
+```bash  
+$ composer require saritasa/laravel-healthcheck  
+```  
+
+Create a new file ```config\health_check.php```:
+```php
+<?php
+
+use Saritasa\LaravelHealthCheck\Checkers\DatabaseHealthChecker;
+use Saritasa\LaravelHealthCheck\Checkers\RedisHealthChecker;
+use Saritasa\LaravelHealthCheck\Checkers\S3HealthChecker;
+
+return [
+    'checkers' => [
+        'database' => DatabaseHealthChecker::class,
+        'redis' => RedisHealthChecker::class,
+        's3' => S3HealthChecker::class,
+    ],
+];
+```
+
+Add the service provider in file ```bootstrap\app.php```:
+
+```php
+$app->configure('health_check');
+
+$app->instance('path.config', app()->basePath() . DIRECTORY_SEPARATOR . 'config');
+$app->register(Saritasa\LaravelHealthCheck\HealthCheckServiceProvider::class);
+``` 
+
 # Usage
 Package exposes endpoints to run all checks or run each check by name:
 ## GET /health

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
             "name": "Sergey Populov",
             "email": "sergey@saritasa.com"
         }
+        ,
+        {
+            "name": "Matias Moncho",
+            "email": "matias.moncho@saritasa.com"
+        }
     ],
     "require": {
         "php": ">=7.1",

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 use Saritasa\LaravelHealthCheck\Http\HealthCheckApiController;
 
@@ -9,7 +8,7 @@ Route::get('livez', HealthCheckApiController::class.'@liveness');
 Route::get('readyz', HealthCheckApiController::class.'@liveness');
 Route::get('healthz', HealthCheckApiController::class.'@index');
 
-Route::prefix('health')->group(function (Router $router) {
+Route::group(['prefix' => 'health'], function ($router) {
     $router->get('', HealthCheckApiController::class.'@index');
     $router->get('{checker}', HealthCheckApiController::class.'@check');
 });


### PR DESCRIPTION
- Removed Laravel specific ```Router``` class from routes, since Lumen and Laravel have different classes: ```Laravel\Lumen\Routing\Router``` and ```Illuminate\Routing\Router```
- Instead of using ```prefix``` method (missing in Lumen), use it as a param
- Added instructions to README.md for publishing the package in Lumen